### PR TITLE
fix: fixes issues after re-integrating component into a project

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,5 @@
         "lint:staged": "lint-staged",
         "prepare": "husky"
     },
-    "version": "1.0.0"
+    "version": "1.0.1"
 }

--- a/src/AppRouterEventsContext.ts
+++ b/src/AppRouterEventsContext.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
 import { createContext } from "react";
 

--- a/src/AppRouterEventsContextProvider.tsx
+++ b/src/AppRouterEventsContextProvider.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { PropsWithChildren, useCallback, useMemo, useState } from "react";
 import { AppRouterEvent, AppRouterEventData, AppRouterEventsContext } from "./AppRouterEventsContext";
 import { NavigateOptions } from "next/dist/shared/lib/app-router-context.shared-runtime";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
-export * from "./AppRouterEventsContextProvider";
-export * from "./useAppRouterEvents";
+"use client";
+
+export { AppRouterEventsContextProvider } from "./AppRouterEventsContextProvider";
+export { useAppRouterEvents } from "./useAppRouterEvents";

--- a/src/useAppRouterEvents.ts
+++ b/src/useAppRouterEvents.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useContext } from "react";
 import { AppRouterEventsContext } from "./AppRouterEventsContext";
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -10,6 +10,7 @@
         "outDir": "./dist/",
         "rootDir": "./",
         "skipLibCheck": true,
+        "sourceMap": true,
         "strict": true,
         "target": "ES2021"
     },


### PR DESCRIPTION
# Description

A few issues were discovered during re-integrating the component into existing project:
- source map is required
- `"use client"` directive is required
- `export *` is not supported by nextjs for client components

# How Has This Been Tested?

This was tested by integrating a component back into https://vocabloo.com project.
